### PR TITLE
Removed waiting for service to start

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,31 +47,6 @@
     - grafana_dashboards
     - grafana_run
 
-- name: Wait for grafana to start (http/s)
-  wait_for:
-    host: "{{ grafana_address }}"
-    port: "{{ grafana_port }}"
-  when: grafana_server.protocol is undefined or grafana_server.protocol in ['http', 'https']
-  tags:
-    - grafana_install
-    - grafana_configure
-    - grafana_datasources
-    - grafana_notifications
-    - grafana_dashboards
-    - grafana_run
-
-- name: Wait for grafana to start (socket)
-  wait_for:
-    path: "{{ grafana_server.socket }}"
-  when: grafana_server.protocol is defined and grafana_server.protocol == 'socket'
-  tags:
-    - grafana_install
-    - grafana_configure
-    - grafana_datasources
-    - grafana_notifications
-    - grafana_dashboards
-    - grafana_run
-
 - include: api_keys.yml
   when: grafana_api_keys | length > 0
   tags:


### PR DESCRIPTION
Removes waiting for services to start as task now fails when grafana_address is empty due to cloud configurations.  