### PR TITLE
Update task modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,17 +22,15 @@
     - grafana_notifications
     - grafana_dashboards
 
-- include: install.yml
-  become: true
+- include_tasks: install.yml
   tags:
     - grafana_install
 
-- include: configure.yml
-  become: true
+- include_tasks: configure.yml
   tags:
     - grafana_configure
 
-- include: plugins.yml
+- include_tasks: plugins.yml
   when: grafana_plugins != []
   tags:
     - grafana_configure
@@ -47,20 +45,20 @@
     - grafana_dashboards
     - grafana_run
 
-- include: api_keys.yml
+- include_tasks: api_keys.yml
   when: grafana_api_keys | length > 0
   tags:
     - grafana_configure
     - grafana_run
 
-- include: datasources.yml
+- include_tasks: datasources.yml
   when: grafana_datasources != []
   tags:
     - grafana_configure
     - grafana_datasources
     - grafana_run
 
-- include: notifications.yml
+- include_tasks: notifications.yml
   when: grafana_alert_notifications | length > 0
   tags:
     - grafana_configure
@@ -68,7 +66,6 @@
     - grafana_run
 
 - name: "Check if there are any dashboards in local {{ grafana_dashboards_dir }}"
-  become: false
   set_fact:
     found_dashboards: "{{ lookup('fileglob', grafana_dashboards_dir + '/*.json', wantlist=True) }}"
   tags:
@@ -76,7 +73,7 @@
     - grafana_dashboards
     - grafana_run
 
-- include: dashboards.yml
+- include_tasks: dashboards.yml
   when: grafana_dashboards | length > 0 or found_dashboards | length > 0
   tags:
     - grafana_configure


### PR DESCRIPTION
Update tasks to use `include_tasks` and removed the `become` from those modules as they're not supported.  Required in order to use newer versions of ansible. 